### PR TITLE
refact: rearranges Telemetry service dependency injection methods 

### DIFF
--- a/src/Liquid.Core/Liquid.Core.csproj
+++ b/src/Liquid.Core/Liquid.Core.csproj
@@ -10,7 +10,7 @@
     <Copyright>Avanade 2019</Copyright>
     <PackageProjectUrl>https://github.com/Avanade/Liquid.Core</PackageProjectUrl>
     <PackageIcon>logo.png</PackageIcon>
-    <Version>2.0.2</Version>
+    <Version>2.1.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProjectGuid>{C33A89FC-4F4D-4274-8D0F-29456BA8F76B}</ProjectGuid>
     <IsPackable>true</IsPackable>

--- a/test/Liquid.Core.Tests/IServiceCollectionLiquidExtensionTest.cs
+++ b/test/Liquid.Core.Tests/IServiceCollectionLiquidExtensionTest.cs
@@ -1,0 +1,79 @@
+﻿using Liquid.Core.Extensions.DependencyInjection;
+using Liquid.Core.Implementations;
+using Liquid.Core.UnitTests.Mocks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using System.Linq;
+using Xunit;
+
+namespace Liquid.Core.Tests
+{
+    public class IServiceCollectionLiquidExtensionTest
+    {
+        private IServiceCollection _sut;
+
+        [Fact]
+        public void AddLiquidTelemetryInterceptor_WhenSuccessfullyInjectsInterceptor_GetServiceSuccessfully()
+        {
+            SetCollection();
+
+            _sut.AddLiquidTelemetryInterceptor<IMockService, MockInterceptService>();
+
+            Assert.NotNull(_sut.FirstOrDefault(x => x.ServiceType == typeof(IMockService) && x.Lifetime == ServiceLifetime.Transient));
+
+            var provider = _sut.BuildServiceProvider();
+
+            Assert.NotNull(provider.GetService<IMockService>());
+        }
+
+        [Fact]
+        public void AddScopedLiquidTelemetry_WhenSuccessfullyInjectsInterceptor_GetServiceSuccessfully()
+        {
+            SetCollection();
+
+            _sut.AddScopedLiquidTelemetry<IMockService, MockInterceptService>();
+
+            Assert.NotNull(_sut.FirstOrDefault(x => x.ServiceType == typeof(IMockService) && x.Lifetime == ServiceLifetime.Scoped));
+
+            var provider = _sut.BuildServiceProvider();
+
+            Assert.NotNull(provider.GetService<IMockService>());
+        }
+
+        private void SetCollection()
+        {
+            _sut = new ServiceCollection();
+            _sut.AddSingleton<MockInterceptService>();
+            _sut.AddSingleton(Substitute.For<ILogger<LiquidTelemetryInterceptor>>());
+        }
+
+        [Fact]
+        public void AddSingletonLiquidTelemetry_WhenSuccessfullyInjectsInterceptor_GetServiceSuccessfully()
+        {
+            SetCollection();
+
+            _sut.AddSingletonLiquidTelemetry<IMockService, MockInterceptService>();
+
+            Assert.NotNull(_sut.FirstOrDefault(x => x.ServiceType == typeof(IMockService) && x.Lifetime == ServiceLifetime.Singleton));
+
+            var provider = _sut.BuildServiceProvider();
+
+            Assert.NotNull(provider.GetService<IMockService>());
+        }
+
+        [Fact]
+        public void AddTransientLiquidTelemetry_WhenSuccessfullyInjectsInterceptor_GetServiceSuccessfully()
+        {
+            SetCollection();
+
+            _sut.AddTransientLiquidTelemetry<IMockService, MockInterceptService>();
+
+            Assert.NotNull(_sut.FirstOrDefault(x => x.ServiceType == typeof(IMockService) && x.Lifetime == ServiceLifetime.Transient));
+
+            var provider = _sut.BuildServiceProvider();
+
+            Assert.NotNull(provider.GetService<IMockService>());
+        }
+    }
+}

--- a/test/Liquid.Core.Tests/Mocks/MockInterceptService.cs
+++ b/test/Liquid.Core.Tests/Mocks/MockInterceptService.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace Liquid.Core.UnitTests.Mocks
+{
+    public class MockInterceptService : IMockService
+    {
+        
+        public MockInterceptService()
+        {
+
+        }
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        public async Task<string> Get()
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        {
+            return "Test";
+        }
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        public async Task<string> GetError()
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
to segregate responsibilities and creates a method for each service lifetime.